### PR TITLE
modify the check on the Content-Type header to allow encoding in the …

### DIFF
--- a/connect/client/mixins.py
+++ b/connect/client/mixins.py
@@ -136,7 +136,7 @@ class AsyncClientMixin:
             await self._execute_http_call(method, url, kwargs)
             if self.response.status_code == 204:
                 return None
-            if self.response.headers.get('Content-Type').startswith('application/json'):
+            if self.response.headers['Content-Type'].startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content

--- a/connect/client/mixins.py
+++ b/connect/client/mixins.py
@@ -60,7 +60,8 @@ class SyncClientMixin:
 
             if self.response.status_code == 204:
                 return None
-            if self.response.headers['Content-Type'].startswith('application/json'):
+            if 'Content-Type' in self.response.headers and \
+                self.response.headers['Content-Type'].startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content
@@ -136,7 +137,8 @@ class AsyncClientMixin:
             await self._execute_http_call(method, url, kwargs)
             if self.response.status_code == 204:
                 return None
-            if self.response.headers['Content-Type'].startswith('application/json'):
+            if 'Content-Type' in self.response.headers and \
+                    self.response.headers['Content-Type'].startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content

--- a/connect/client/mixins.py
+++ b/connect/client/mixins.py
@@ -61,7 +61,7 @@ class SyncClientMixin:
             if self.response.status_code == 204:
                 return None
             if 'Content-Type' in self.response.headers and \
-                self.response.headers['Content-Type'].startswith('application/json'):
+                    self.response.headers['Content-Type'].startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content

--- a/connect/client/mixins.py
+++ b/connect/client/mixins.py
@@ -60,7 +60,7 @@ class SyncClientMixin:
 
             if self.response.status_code == 204:
                 return None
-            if self.response.headers['Content-Type'] == 'application/json':
+            if self.response.headers['Content-Type'].startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content
@@ -136,7 +136,7 @@ class AsyncClientMixin:
             await self._execute_http_call(method, url, kwargs)
             if self.response.status_code == 204:
                 return None
-            if self.response.headers.get('Content-Type') == 'application/json':
+            if self.response.headers.get('Content-Type').startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content

--- a/connect/client/mixins.py
+++ b/connect/client/mixins.py
@@ -60,8 +60,7 @@ class SyncClientMixin:
 
             if self.response.status_code == 204:
                 return None
-            if 'Content-Type' in self.response.headers and \
-                    self.response.headers['Content-Type'].startswith('application/json'):
+            if self.response.headers.get('Content-Type', '').startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content
@@ -137,8 +136,7 @@ class AsyncClientMixin:
             await self._execute_http_call(method, url, kwargs)
             if self.response.status_code == 204:
                 return None
-            if 'Content-Type' in self.response.headers and \
-                    self.response.headers['Content-Type'].startswith('application/json'):
+            if self.response.headers.get('Content-Type', '').startswith('application/json'):
                 return self.response.json()
             else:
                 return self.response.content


### PR DESCRIPTION
The condition to try to parse the content of the response as json is content-type == 'application/json', but in some cases the "Content Type" header can include the charset, so accessing the header with requests library will outcome values like
application/json;charset=utf-8.

That makes the client return the raw content (self.response.content).

https://developer.mozilla.org/es/docs/Web/HTTP/Headers/Content-Type