### PR TITLE
LITE-33583: Add Python 3.13 and 3.14 to the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/connect/client/models/iterators.py
+++ b/connect/client/models/iterators.py
@@ -33,6 +33,9 @@ class AbstractBaseIterator:
 
 
 class AbstractIterator(AbstractBaseIterator):
+    def __iter__(self):
+        return self
+
     def _load(self):
         if not self._loaded:
             self._rs._results, self._rs._content_range = self._execute_request()
@@ -83,6 +86,9 @@ class AbstractIterator(AbstractBaseIterator):
 
 
 class AbstractAsyncIterator(AbstractBaseIterator):
+    def __aiter__(self):
+        return self
+
     async def _load(self):
         if not self._loaded:
             self._rs._results, self._rs._content_range = await self._execute_request()

--- a/poetry.lock
+++ b/poetry.lock
@@ -607,31 +607,31 @@ colorama = ">=0.4"
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
 name = "httpcore"
-version = "1.0.6"
+version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
-    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
 ]
 
 [package.dependencies]
 certifi = "*"
-h11 = ">=0.13,<0.15"
+h11 = ">=0.16"
 
 [package.extras]
 asyncio = ["anyio (>=4.0,<5.0)"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
     "Topic :: Software Development :: Libraries",
 ]


### PR DESCRIPTION
## Summary

Extends the CI build matrix and PyPI trove classifiers to cover Python **3.13** and **3.14**.

Merge first [PR 86 ](https://github.com/cloudblue/connect-python-openapi-client/pull/86)  (this depends on its httpx/pytest-httpx bump).

## Changes

- **`.github/workflows/build.yml`** — matrix now `['3.10', '3.11', '3.12', '3.13', '3.14']`
- **`pyproject.toml`** — added 3.13/3.14 trove classifiers
- **`connect/client/models/iterators.py`** — added `__iter__`/`__aiter__` returning `self` to `AbstractIterator`/`AbstractAsyncIterator`. Python 3.13+ enforces that the object returned by `__iter__` must itself be a proper iterator; without this, iterating a `ResourceSet` raised `TypeError: 'ResourceIterator' object is not iterable`.
- **`poetry.lock`** — bumped `httpcore` 1.0.6 → 1.0.9 (and `h11` 0.14 → 0.16). httpcore 1.0.6 crashed at import on Python 3.14. Both are transitive deps, so no `pyproject` pin change.

## Testing

All **407 tests pass on Python 3.12, 3.13 and 3.14**; flake8 clean on source.