### PR TITLE
ci: fix Node 20 deprecation warning in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python '3.10.0'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,11 @@ jobs:
         run: |
           sed -i 's/\/home\/runner\/work\/connect-python-openapi-client\/connect-python-openapi-client\//\/github\/workspace\//g' coverage.xml
       - name: SonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
       - name: Wait sonar to process report
         uses: jakejarvis/wait-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         poetry run pytest
     - name: Extract tag name
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       id: tag
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub Actions runners are dropping Node 20 support, so actions still pinned to it are being force-run on Node 24 with a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

This branch bumps every affected action to a current major version that targets the required Node runtime natively, and replaces the deprecated SonarScanner action.

### Node runtime bumps

- `actions/checkout` v3 → v7 (`build.yml`, `deploy.yml`)
- `actions/setup-python` v4 → v6 (`build.yml`, `deploy.yml`)
- `actions/github-script` v6 → v9 (`deploy.yml`) — v6 runs on Node 16, v9 on Node 24

### SonarCloud action replacement

- `SonarSource/sonarcloud-github-action@master` → `SonarSource/sonarqube-scan-action@v8` (`build.yml`)

`sonarcloud-github-action` is deprecated in favour of `sonarqube-scan-action`, and its internals still pull `actions/cache@v4` (Node 20), which is the source of the remaining cache deprecation warning. The replacement runs on Node 24. Added `SONAR_HOST_URL: https://sonarcloud.io` since the generic scan action has no SonarCloud default; `projectKey`/`organization` already live in `sonar-project.properties`.

## Notes

- The `@master`-pinned `jakejarvis/wait-action` and `sonarsource/sonarqube-quality-gate-action` in `build.yml` are left untouched — they float already and don't emit the deprecation warning.

Ref: [LITE-33583](https://imorg.atlassian.net/browse/LITE-33583)